### PR TITLE
installation refinement

### DIFF
--- a/server/install_server.sh
+++ b/server/install_server.sh
@@ -30,8 +30,8 @@ git checkout 5.0
 make
 popd
 
-# LAUNCH Redis
-bash ${AIL_BIN}LAUNCH.sh -lrv &
+# LAUNCH
+bash LAUNCH.sh -l &
 wait
 echo ""
 

--- a/server/requirement.txt
+++ b/server/requirement.txt
@@ -1,8 +1,9 @@
 twisted[tls]
 redis
-flask
+flask==2.2.2
 flask-login
 bcrypt
+Werkzeug==2.2.2
 
 #sudo python3 -m pip install --upgrade service_identity
 


### PR DESCRIPTION
This commit fixes two issues noticed while installing and testing the d4core server: one with the install_server.sh script and one with python package versions.

install_server.sh references a non-existent AIL environment variable and (attempts) to call LAUNCH.sh with non existent arguments.

the d4core server fails to LAUNCH.sh on Ubuntu 20.04 with Python 3.8.10 due to a missing requirement (werkzeug) and a newer, incompatible, version of flask.

